### PR TITLE
refacator: remove lombok and improve Task instantiation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
 		<maven.compiler.release>21</maven.compiler.release>
 		<java.version>21</java.version>
 		<picocli.version>4.7.7</picocli.version>
-		<lombok.version>1.18.44</lombok.version>
 		<main.class>com.laporeon.taskr.Taskr</main.class>
 	</properties>
 	<dependencies>
@@ -26,12 +25,6 @@
 			<groupId>info.picocli</groupId>
 			<artifactId>picocli</artifactId>
 			<version>${picocli.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>${lombok.version}</version>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/com/laporeon/taskr/entities/Task.java
+++ b/src/main/java/com/laporeon/taskr/entities/Task.java
@@ -2,14 +2,10 @@ package com.laporeon.taskr.entities;
 
 import com.laporeon.taskr.enums.TaskPriority;
 import com.laporeon.taskr.enums.TaskStatus;
-import lombok.Builder;
-import lombok.Getter;
 
 import java.time.Instant;
 import java.util.UUID;
 
-@Builder
-@Getter
 public class Task {
 
     private UUID id;
@@ -19,12 +15,51 @@ public class Task {
     private Instant createdAt;
     private Instant updatedAt;
 
-    public void update(String title, TaskStatus status, TaskPriority priority) {
-        if (title != null) this.title = title;
-        if (status != null) this.status = status;
-        if (priority != null) this.priority = priority;
-
-        this.updatedAt = Instant.now();
+    public UUID getId() {
+        return id;
     }
 
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public TaskPriority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(TaskPriority priority) {
+        this.priority = priority;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/com/laporeon/taskr/enums/TaskPriority.java
+++ b/src/main/java/com/laporeon/taskr/enums/TaskPriority.java
@@ -1,11 +1,9 @@
 package com.laporeon.taskr.enums;
 
 import com.laporeon.taskr.exceptions.InvalidArgumentException;
-import lombok.Getter;
 
 import java.util.Arrays;
 
-@Getter
 public enum TaskPriority {
 
     LOW("low", "●○○", Color.GREEN),
@@ -20,6 +18,10 @@ public enum TaskPriority {
         this.value = value;
         this.symbol = symbol;
         this.color = color;
+    }
+
+    public String getValue() {
+        return value;
     }
 
     public String getColoredSymbol() {

--- a/src/main/java/com/laporeon/taskr/enums/TaskStatus.java
+++ b/src/main/java/com/laporeon/taskr/enums/TaskStatus.java
@@ -1,11 +1,9 @@
 package com.laporeon.taskr.enums;
 
 import com.laporeon.taskr.exceptions.InvalidArgumentException;
-import lombok.Getter;
 
 import java.util.Arrays;
 
-@Getter
 public enum TaskStatus {
 
     TODO("todo", "\u25A1", Color.YELLOW),
@@ -22,6 +20,10 @@ public enum TaskStatus {
         this.color = color;
     }
 
+    public String getValue() {
+        return value;
+    }
+
     public String getColoredSymbol() {
         return color.apply(symbol);
     }
@@ -36,4 +38,5 @@ public enum TaskStatus {
                 .findFirst()
                 .orElseThrow(() -> new InvalidArgumentException(INVALID_STATUS_VALUE_ERROR.formatted(status)));
     }
+
 }

--- a/src/main/java/com/laporeon/taskr/helpers/FileStorageHandler.java
+++ b/src/main/java/com/laporeon/taskr/helpers/FileStorageHandler.java
@@ -1,8 +1,6 @@
 package com.laporeon.taskr.helpers;
 
 import com.laporeon.taskr.entities.Task;
-import com.laporeon.taskr.enums.TaskPriority;
-import com.laporeon.taskr.enums.TaskStatus;
 import com.laporeon.taskr.exceptions.TaskStorageException;
 
 import java.io.BufferedReader;
@@ -12,10 +10,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 public class FileStorageHandler {
 
@@ -50,15 +46,7 @@ public class FileStorageHandler {
                     throw new TaskStorageException(INVALID_ATTRIBUTES_SIZE_MESSAGE.formatted(TASK_ATTRIBUTES_SIZE, attributes.length));
                 }
 
-                Task task = Task.builder()
-                        .id(UUID.fromString(attributes[0]))
-                        .title(attributes[1])
-                        .status(TaskStatus.fromString(attributes[2]))
-                        .priority(TaskPriority.fromString(attributes[3]))
-                        .createdAt(Instant.parse(attributes[4]))
-                        .updatedAt(Instant.parse(attributes[5]))
-                        .build();
-
+                Task task = TaskSerializer.fromFields(attributes);
                 tasks.add(task);
             }
 

--- a/src/main/java/com/laporeon/taskr/helpers/TaskSerializer.java
+++ b/src/main/java/com/laporeon/taskr/helpers/TaskSerializer.java
@@ -2,9 +2,35 @@ package com.laporeon.taskr.helpers;
 
 import com.laporeon.taskr.entities.Task;
 import com.laporeon.taskr.enums.Color;
+import com.laporeon.taskr.enums.TaskPriority;
 import com.laporeon.taskr.enums.TaskStatus;
 
+import java.time.Instant;
+import java.util.UUID;
+
 public class TaskSerializer {
+
+    public static Task fromFields(String[] attributes) {
+        Task task = new Task();
+        task.setId(UUID.fromString(attributes[0]));
+        task.setTitle(attributes[1]);
+        task.setStatus(TaskStatus.fromString(attributes[2]));
+        task.setPriority(TaskPriority.fromString(attributes[3]));
+        task.setCreatedAt(Instant.parse(attributes[4]));
+        task.setUpdatedAt(Instant.parse(attributes[5]));
+        return task;
+    }
+
+    public static Task toEntity(String title, TaskStatus status, TaskPriority priority) {
+        Task task = new Task();
+        task.setId(UUID.randomUUID());
+        task.setTitle(title);
+        task.setStatus(status);
+        task.setPriority(priority);
+        task.setCreatedAt(Instant.now());
+        task.setUpdatedAt(Instant.now());
+        return task;
+    }
 
     public static String toCsvString(Task task) {
         return String.format(

--- a/src/main/java/com/laporeon/taskr/repositories/TaskRepository.java
+++ b/src/main/java/com/laporeon/taskr/repositories/TaskRepository.java
@@ -5,6 +5,7 @@ import com.laporeon.taskr.enums.TaskPriority;
 import com.laporeon.taskr.enums.TaskStatus;
 import com.laporeon.taskr.helpers.FileStorageHandler;
 
+import java.time.Instant;
 import java.util.List;
 
 public class TaskRepository {
@@ -28,7 +29,12 @@ public class TaskRepository {
         List<Task> tasks = FileStorageHandler.readFile();
 
         Task task = tasks.get(index - 1);
-        task.update(title, status, priority);
+
+        if (title != null) task.setTitle(title);
+        if (status != null) task.setStatus(status);
+        if (priority != null) task.setPriority(priority);
+
+        task.setUpdatedAt(Instant.now());
 
         FileStorageHandler.overwriteFileContent(tasks);
     }

--- a/src/main/java/com/laporeon/taskr/services/TaskService.java
+++ b/src/main/java/com/laporeon/taskr/services/TaskService.java
@@ -4,11 +4,10 @@ import com.laporeon.taskr.entities.Task;
 import com.laporeon.taskr.enums.TaskPriority;
 import com.laporeon.taskr.enums.TaskStatus;
 import com.laporeon.taskr.exceptions.InvalidArgumentException;
+import com.laporeon.taskr.helpers.TaskSerializer;
 import com.laporeon.taskr.repositories.TaskRepository;
 
-import java.time.Instant;
 import java.util.List;
-import java.util.UUID;
 
 public class TaskService {
 
@@ -19,15 +18,7 @@ public class TaskService {
     }
 
     public void createTask(String title, TaskStatus status, TaskPriority priority) {
-        Task task = Task.builder()
-                        .id(UUID.randomUUID())
-                        .title(title)
-                        .status(status)
-                        .priority(priority)
-                        .createdAt(Instant.now())
-                        .updatedAt(Instant.now())
-                        .build();
-
+        Task task = TaskSerializer.toEntity(title, status, priority);
         taskRepository.save(task);
     }
 


### PR DESCRIPTION
## What changed

- Removed Lombok dependency since it is unnecessary for a plain CLI project with no DI framework.
- Replaced `@Builder` with `TaskSerializer.toEntity()` and `fromFields()` factory methods, centralizing Task instantiation and deserialization in a single place.
- Removed Task update logic from Entity and moved to the repository layer, keeping the entity as a plain data holder.
- Added native getters and setters to `Task`, `TaskStatus`, and `TaskPriority`.